### PR TITLE
Enable config setting via environment variables

### DIFF
--- a/gauge-testrail-config/src/main/java/de/nexible/gauge/testrail/config/Environment.java
+++ b/gauge-testrail-config/src/main/java/de/nexible/gauge/testrail/config/Environment.java
@@ -1,0 +1,33 @@
+package de.nexible.gauge.testrail.config;
+
+/**
+ * The {@link Environment} class provides environment utility methods.
+ *
+ * @author johnboyes
+ */
+public class Environment {
+
+	/** Prevent the class being instantiated */
+	private Environment() {
+	}
+
+	/**
+	 * 
+	 * Gets the value of the environment variable for the given name, or the value
+	 * for the name converted to uppercase with underscores replacing dots.
+	 * 
+	 * @param name the name of the environment variable
+	 * @return the string value of the environment variable for the given name, or
+	 *         the value for the name converted to uppercase with underscores
+	 *         replacing dots, or {@code null} if neither is defined in the
+	 *         environment
+	 */
+	public static String get(String name) {
+		String getenv = System.getenv(name);
+		if (getenv != null)
+			return getenv;
+		name = name.toUpperCase().replace('.', '_');
+		return System.getenv(name);
+	}
+
+}

--- a/gauge-testrail-config/src/main/java/de/nexible/gauge/testrail/config/GaugeDefaultContext.java
+++ b/gauge-testrail-config/src/main/java/de/nexible/gauge/testrail/config/GaugeDefaultContext.java
@@ -1,13 +1,11 @@
 package de.nexible.gauge.testrail.config;
 
-import static java.lang.System.getenv;
-
 public class GaugeDefaultContext implements GaugeContext {
     public String getGaugeProjectRoot() {
-        return getenv("GAUGE_PROJECT_ROOT");
+        return Environment.get("GAUGE_PROJECT_ROOT");
     }
 
     public String getGaugeLogDir() {
-        return System.getenv("logs_directory");
+        return Environment.get("logs_directory");
     }
 }

--- a/gauge-testrail-config/src/main/java/de/nexible/gauge/testrail/config/TestRailDefaultContext.java
+++ b/gauge-testrail-config/src/main/java/de/nexible/gauge/testrail/config/TestRailDefaultContext.java
@@ -24,7 +24,7 @@ public class TestRailDefaultContext implements TestRailContext {
     }
 
     protected boolean readBoolean(String key) {
-        String value = System.getenv(key);
+        String value = Environment.get(key);
         if (!Strings.isNullOrEmpty(value)) {
             return Boolean.parseBoolean(value.trim());
         }
@@ -32,12 +32,12 @@ public class TestRailDefaultContext implements TestRailContext {
     }
 
     private String read(String key) {
-        return System.getenv(key).trim();
+        return Environment.get(key).trim();
     }
 
     @Override
     public Level getLogLevel() {
-        return readLogLevel(System.getenv("testrail.loglevel"));
+        return readLogLevel(Environment.get("testrail.loglevel"));
     }
 
     private Level readLogLevel(String level) {

--- a/gauge-testrail-config/src/test/java/de/nexible/gauge/testrail/config/EnvironmentTest.java
+++ b/gauge-testrail-config/src/test/java/de/nexible/gauge/testrail/config/EnvironmentTest.java
@@ -1,0 +1,31 @@
+package de.nexible.gauge.testrail.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EnvironmentTest {
+  @Test
+  @DisplayName("Environment variables can be set with underscores as well as period-separated names")
+  public void environmentVariablesCanBeSetWithUnderscoresAsWellAsPeriodSeparatedNames() throws Exception {
+    List<String> actual = List.of(
+        withEnvironmentVariable("TESTRAIL_URL", "https://underscores.testrail.io")
+            .execute(() -> Environment.get("testrail.url")),
+        withEnvironmentVariable("testrail.url", "https://period-separated.testrail.io")
+            .execute(() -> Environment.get("testrail.url")));
+    assertThat(actual).isEqualTo(List.of("https://underscores.testrail.io", "https://period-separated.testrail.io"));
+  }
+
+  @Test
+  @DisplayName("Period separated names override names with underscores if both set")
+  public void periodSeparatedOverridesUnderscoresIfBothSet() throws Exception {
+    String actual = withEnvironmentVariable("TESTRAIL_URL", "https://underscores.testrail.io")
+        .and("testrail.url", "https://period-separated.testrail.io").execute(() -> Environment.get("testrail.url"));
+    assertThat(actual).isEqualTo("https://period-separated.testrail.io");
+  }
+
+}

--- a/gauge-testrail-report/README.md
+++ b/gauge-testrail-report/README.md
@@ -32,6 +32,8 @@ testrail.url = // the base url of the TestRail instance
 testrail.run.id = // the id of the testrun to post the results to
 ```
 
+Alternatively instead of the properties file you can use environment variables (in upper case, with underscore as the separator rather than a dot), e.g. `TESTRAIL_USER`.
+
 ### Uninstall plugin
 Call `gauge uninstall testrail` and remove the entry from the `manifest.json` of the gauge project
 

--- a/gauge-testrail-report/src/main/java/de/nexible/gauge/testrail/GaugeConnector.java
+++ b/gauge-testrail-report/src/main/java/de/nexible/gauge/testrail/GaugeConnector.java
@@ -2,6 +2,7 @@ package de.nexible.gauge.testrail;
 
 import com.gurock.testrail.APIException;
 import com.thoughtworks.gauge.Messages;
+import de.nexible.gauge.testrail.config.Environment;
 
 import java.io.IOException;
 import java.net.Socket;
@@ -11,7 +12,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 import static java.lang.Integer.parseInt;
-import static java.lang.System.getenv;
 
 /**
  * The {@link GaugeConnector} opens a socket to listen to gauge events and propagates the event
@@ -34,7 +34,7 @@ public class GaugeConnector {
      * Opens a socket to listen to gauge events
      */
     public void connect() {
-        int port = parseInt(getenv("plugin_connection_port"));
+        int port = parseInt(Environment.get("plugin_connection_port"));
         logger.info(() -> "connecting to gauge port " + port);
         while (true) {
             try {

--- a/gauge-testrail-report/src/main/java/de/nexible/gauge/testrail/context/TestRailReportDefaultContext.java
+++ b/gauge-testrail-report/src/main/java/de/nexible/gauge/testrail/context/TestRailReportDefaultContext.java
@@ -1,5 +1,6 @@
 package de.nexible.gauge.testrail.context;
 
+import de.nexible.gauge.testrail.config.Environment;
 import de.nexible.gauge.testrail.config.TestRailContext;
 import de.nexible.gauge.testrail.config.TestRailDefaultContext;
 
@@ -16,6 +17,6 @@ import java.nio.file.Path;
 public class TestRailReportDefaultContext extends TestRailDefaultContext implements TestRailReportContext {
     @Override
     public String getTestRailRunId() {
-        return System.getenv("testrail.run.id");
+        return Environment.get("testrail.run.id");
     }
 }

--- a/gauge-testrail-sync/README.md
+++ b/gauge-testrail-sync/README.md
@@ -33,6 +33,8 @@ testrail.gauge.template = // the testrail template to use (it expects to have th
 testrail.automation.type = // optional. the id of the automation type to use
 ```
 
+Alternatively instead of the properties file you can use environment variables (in upper case, with underscore as the separator rather than a dot), e.g. `TESTRAIL_USER`.
+
 Call `gauge docs testrail-sync`
 
 ### Uninstall plugin

--- a/gauge-testrail-sync/src/main/java/de/nexible/gauge/testrail/sync/context/TestRailSyncDefaultContext.java
+++ b/gauge-testrail-sync/src/main/java/de/nexible/gauge/testrail/sync/context/TestRailSyncDefaultContext.java
@@ -1,10 +1,10 @@
 package de.nexible.gauge.testrail.sync.context;
 
+import de.nexible.gauge.testrail.config.Environment;
 import de.nexible.gauge.testrail.config.TestRailDefaultContext;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.Integer.parseInt;
-import static java.lang.System.getenv;
 
 /**
  * A {@link TestRailSyncContext} that is used when the plugin runs inside of gauge test run
@@ -40,7 +40,7 @@ public class TestRailSyncDefaultContext extends TestRailDefaultContext implement
     }
 
     private int read(String s) {
-        String getenv = getenv(s);
+        String getenv = Environment.get(s);
         if (isNullOrEmpty(getenv)) {
             return UNKNOWN;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
             <version>3.10.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-lambda</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 </project>


### PR DESCRIPTION
It is useful to be able to set the configuration properties via
environment variables, as well as / instead of via properties files.

Most operating systems disallow period-separated key names for
environment variables, so this commit enables using the underscore
format for environment variables in addition to the existing
period-separated format (for example, `TESTRAIL_URL` as well as
`testrail.url`).

Fixes #2 